### PR TITLE
Changed relationship between HGVS annotation node and ClinVar IRI

### DIFF
--- a/YARRRML_Transform_Templates/templates/undiagnosed_yarrrml_template.yaml
+++ b/YARRRML_Transform_Templates/templates/undiagnosed_yarrrml_template.yaml
@@ -269,6 +269,10 @@ mappings:
         type: iri
     - predicates: rdf:type
       objects:
+        value: http://purl.obolibrary.org/obo/NCIT_C172243
+        type: iri
+    - predicates: http://semanticscience.org/resource/SIO_000001
+      objects:
         value: "$(clinvar_uri)"
         type: iri
     - predicates: rdfs:label


### PR DESCRIPTION
With this PR I am proposing changes in relationship between `HGVS annotation node` and `ClinVar IRI`. In the current implementation `ClinVar IRI` is used as `rdf:type` of  `HGVS annotation node`. In the proposal I am typing `HGVS annotation node` as rdf:type `NCIT:HGVS Genomic Variation Annotation` and connecting it to ClinVar IRI by `SIO:is related to` predicate