### PR TITLE
Exemplar csv links

### DIFF
--- a/YARRRML_Transform_Templates/docs/body_measurement_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/body_measurement_csv_template.md
@@ -5,7 +5,7 @@ The DCDE to capture any physical measurement of the body
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/body_measurement.csv)
+Please find example CSV file [here](../exemplar_csv/body_measurement.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/care_pathway_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/care_pathway_csv_template.md
@@ -5,7 +5,7 @@ The care pathway (currently limited to first-contact information)
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/care_pathway.csv)
+Please find example CSV file [here](../exemplar_csv/care_pathway.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/diagnosis_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/diagnosis_csv_template.md
@@ -5,7 +5,7 @@ The diagnostic opinion regarding the disease
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/diagnosis.csv)
+Please find example CSV file [here](../exemplar_csv/diagnosis.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/disability_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/disability_csv_template.md
@@ -5,7 +5,7 @@ Measurement of disability using some standardized assessment test
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/phenotyping.csv)
+Please find example CSV file [here](../exemplar_csv/phenotyping.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/disease_history_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/disease_history_csv_template.md
@@ -5,7 +5,7 @@ The CDE for disease history ("age" at onset, "age" at diagnosis)
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/disease_history.csv)
+Please find example CSV file [here](../exemplar_csv/disease_history.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/disease_progression_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/disease_progression_csv_template.md
@@ -5,7 +5,7 @@ The longitudinal record of a patient's observations through the course of their 
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/disease_progression.csv)
+Please find example CSV file [here](../exemplar_csv/disease_progression.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/genetic_diagnosis_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/genetic_diagnosis_csv_template.md
@@ -5,7 +5,7 @@ The CDE for genetic diagnosis
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/genetic_diagnosis.csv)
+Please find example CSV file [here](../exemplar_csv/genetic_diagnosis.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/imaging_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/imaging_csv_template.md
@@ -5,7 +5,7 @@ The DCDE to capture any imaging data
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/imaging.csv)
+Please find example CSV file [here](../exemplar_csv/imaging.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/lab_measurement_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/lab_measurement_csv_template.md
@@ -5,7 +5,7 @@ The DCDE to capture any laboratory measurement (e.g. a blood chemistry test)
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/lab_measurement.csv)
+Please find example CSV file [here](../exemplar_csv/lab_measurement.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/patient_consent_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/patient_consent_csv_template.md
@@ -5,7 +5,7 @@ The CDE for patient status
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/patient_consent.csv)
+Please find example CSV file [here](../exemplar_csv/patient_consent.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/patient_status_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/patient_status_csv_template.md
@@ -5,7 +5,7 @@ The CDE for patient status
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/patient_status.csv)
+Please find example CSV file [here](../exemplar_csv/patient_status.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/personal_information_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/personal_information_csv_template.md
@@ -5,7 +5,7 @@ The CDE for personal information (birth date and sex)
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/personal.csv)
+Please find example CSV file [here](../exemplar_csv/personal.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/phenotyping_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/phenotyping_csv_template.md
@@ -5,7 +5,7 @@ A record of the phenotypic observations for a patient
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/phenotyping.csv)
+Please find example CSV file [here](../exemplar_csv/phenotyping.csv)
 
 ### Columns
 

--- a/YARRRML_Transform_Templates/docs/undiagnosed_csv_template.md
+++ b/YARRRML_Transform_Templates/docs/undiagnosed_csv_template.md
@@ -5,7 +5,7 @@ A combination of a variant and a phenotype that cannot be definitively diagnosed
 ## CSV file 
 
 ### Example CSV file
-Please find example CSV file [here](../csv/undiagnosed.csv)
+Please find example CSV file [here](../exemplar_csv/undiagnosed.csv)
 
 ### Columns
 


### PR DESCRIPTION
The links for the exemplar csv files in the docs are broken. In this PR I replaced the broken links